### PR TITLE
Add playbooks to import/export server configuration profile

### DIFF
--- a/ansible_enroll/README.md
+++ b/ansible_enroll/README.md
@@ -50,4 +50,37 @@ Also make sure you open the port on the firewall:
 ansible-playbook update-firmware.yml -i inventory/
 ```
 
+## Exporting and importing server configuration
 
+### Exporting current configuration
+
+Select a server to act as reference machine 
+
+```
+(venv-arcus) [will@cumulus-seed ansible_enroll]$ ansible-playbook -i inventory/ export-configuration.yml --limit svn2-dr06-u21
+```
+
+### Import
+
+Create a reference configuration. This can be the file you exported earlier unchanged or you can select
+a set of attributes to apply:
+
+```
+(venv-arcus) [will@cumulus-seed ansible_enroll]$ ./configuration-filter.py --input data/10.202.100.200_20200903_125655_scp.json --component-filter "iDRAC.Embedded.1" --attr-filter "SysLog.1.*" "IPMILan.1#AlertEnable" --component-filter "EventFilters.*" --attr-filter ".*"  | jq . > data/reference-configuration.json
+```
+
+In the example above, we are copying the configuration need to enable remote syslog output.
+
+Run the playbook to import the reference confiuration:
+
+```
+(venv-arcus) [will@cumulus-seed ansible_enroll]$ ansible-playbook -i inventory/ export-configuration.yml --limit svn2-dr06-u21
+```
+
+### Testing the configuration
+
+Prerequisites: install racadm in docker container
+
+```
+(venv-arcus) [will@cumulus-seed ~]$ sudo docker exec -it will-testin /opt/dell/srvadmin/bin/idracadm7 -r 10.202.100.162 -u root -p calvin eventfilters test -i PSU0001
+```

--- a/ansible_enroll/configuration-filter.py
+++ b/ansible_enroll/configuration-filter.py
@@ -1,0 +1,54 @@
+#!/bin/env python
+
+import json
+import argparse
+import fileinput
+import re
+import sys
+
+def filter_attr(component, regexps):
+    if not regexps:
+        return component
+    if "Attributes" not in component:
+        # no attributes to filter
+        return component
+    attrs = component["Attributes"]
+    component["Attributes"] = [x for x in attrs if re.match("|".join(regexps), x["Name"])]
+    return component
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='Filter system configuration')
+    parser.add_argument('--attr-filter', metavar='', nargs='*', action="append",
+                        help='Filter attributes', default=[])
+    parser.add_argument('--component-filter', metavar='', nargs='*', action="append",
+                    help='Filter components', default=[])
+    parser.add_argument('--input', metavar='', nargs='?', help='input file', default=[])
+
+    args = parser.parse_args()
+    # flatten
+    component_filters = sum(args.component_filter, [])
+
+    if len(component_filters) != len(args.attr_filter):
+        print("Missing attr-filter for a component", sys.stderr)
+        sys.exit(1)
+
+    buffer = []
+    for line in fileinput.input(args.input):
+        buffer.append(line)
+
+    content = json.loads("\n".join(buffer))
+    components = content["SystemConfiguration"]["Components"]
+
+    filtered = []
+    for component in components:
+        for i, regex in enumerate(component_filters):
+            if re.match(regex, component["FQDD"]):
+                filtered.append(filter_attr(component, args.attr_filter[i]))
+    # [filter_attr(x, args.attr_filter[i]) for i, x in enumerate(components) if not component_filters or re.match("|".join(component_filters), x["FQDD"])]
+    # filter_attr returns none on no attributes
+    content["SystemConfiguration"]["Components"] = [x for x in filtered if x]
+
+    print(json.dumps(content))
+
+

--- a/ansible_enroll/export-configuration.yml
+++ b/ansible_enroll/export-configuration.yml
@@ -1,0 +1,22 @@
+---
+- hosts: baremetal-compute
+  gather_facts: false
+
+  collections:
+   - dellemc.openmanage
+
+  tasks:
+    - name: Export Server Configuration Profile
+      idrac_server_config_profile:
+        idrac_ip: "{{ idrac_ip }}"
+        idrac_user: "{{ idrac_user }}"
+        idrac_password: "{{ idrac_password }}"
+        idrac_port:      "443"
+        share_name:      "{{ playbook_dir }}/data/"
+        job_wait:        "True"
+        export_format:   "JSON"
+      register: idrac_firmware_output
+      delegate_to: localhost
+
+    - debug:
+        var: idrac_firmware_output

--- a/ansible_enroll/import-configuration.yml
+++ b/ansible_enroll/import-configuration.yml
@@ -1,0 +1,28 @@
+---
+# WARNING: This playbook will reboot your servers
+
+- hosts: baremetal-compute
+  gather_facts: false
+
+  collections:
+   - dellemc.openmanage
+
+  tasks:
+    - name: Import Server Configuration Profile
+      idrac_server_config_profile:
+        idrac_ip: "{{ idrac_ip }}"
+        idrac_user: "{{ idrac_user }}"
+        idrac_password: "{{ idrac_password }}"
+        idrac_port: "443"
+        share_name: "{{ playbook_dir }}/data/"
+        command: import
+        scp_file: "reference-configuration.json"
+        job_wait: "True"
+        # Graceful, Forced, NoReboot
+        # shutdown_type: "NoReboot"
+        # end_host_power_state: On
+      register: idrac_import_output
+      delegate_to: localhost
+
+    - debug:
+        var: idrac_import_output


### PR DESCRIPTION
I used this to enable remote syslog, but it could be used to synchronise the configuration of bios/idrac across the whole group of servers. The default export will synchronise configuration in a non destructive way e.g virtual disks are preserved, see:

https://downloads.dell.com/solutions/dell-management-solution-resources/Server%20Cloning%20with%20Server%20Configuration%20Profiles%201_1%20Final.pdf